### PR TITLE
Dependencies for the examples

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,5 @@ setup(
     author='Szabolcs Dombi',
     author_email='cprogrammer1994@gmail.com',
     license='MIT',
+    install_requires=['numpy'],
 )

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,7 @@ setup(
     author='Szabolcs Dombi',
     author_email='cprogrammer1994@gmail.com',
     license='MIT',
-    install_requires=['numpy'],
+    setup_requires={
+        'examples': ['numpy'],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,17 @@ setup(
     author='Szabolcs Dombi',
     author_email='cprogrammer1994@gmail.com',
     license='MIT',
-    setup_requires={
-        'examples': ['numpy'],
+    extras_require={
+        'examples': [
+            'ffmpeg',
+            'glcontext',
+            'numpy',
+            'objloader',
+            'pyglet',
+            'pillow',
+            'pybullet',
+            'sdf',
+            'scimage',
+        ],
     },
 )


### PR DESCRIPTION
I noticed that `numpy` was a requirement to use this library.

I suppose that `pyglet` also could be added to this list, but since it technically only is used for the examples that part was less clear to me. I could add it to this MR as an optional feature if you'd like (through use of `extras_requires`).