### PR TITLE
Convert string formatting to f-strings

### DIFF
--- a/examples/ffmpeg_stream.py
+++ b/examples/ffmpeg_stream.py
@@ -109,7 +109,7 @@ process1 = (
 
 process2 = (
     ffmpeg
-    .input('pipe:', format='rawvideo', pix_fmt='rgb24', s='{}x{}'.format(width, height))
+    .input('pipe:', format='rawvideo', pix_fmt='rgb24', s=f'{width}x{height}')
     .vflip()
     .output(out_filename, pix_fmt='yuv420p')
     .overwrite_output()

--- a/examples/grass.py
+++ b/examples/grass.py
@@ -16,7 +16,7 @@ def grass_mesh():
         verts.append((c[i] * 0.03, b[i] * 0.2, a[i]))
     verts.append((0.0, 0.2, 1.0))
     verts = ','.join('vec3(%.8f, %.8f, %.8f)' % x for x in verts)
-    return 'vec3 grass[15] = vec3[](%s);' % verts
+    return f'vec3 grass[15] = vec3[]({verts});'
 
 
 window = Window(1280, 720)


### PR DESCRIPTION
Since this project is Python 3.6+, string formatting could just as well use the faster and more convenient f-strings.

This was a mechanical conversion with pyupgrade and flynt, followed up by some manual fixups.