### PR TITLE
Bind uniform arrays with proper names

### DIFF
--- a/_zengl.py
+++ b/_zengl.py
@@ -376,7 +376,7 @@ def flatten(iterable):
 
 def uniforms(uniforms, values):
     data = bytearray()
-    uniform_map = {obj['name']: obj for obj in uniforms}
+    uniform_map = {obj['name'].replace('[0]', ''): obj for obj in uniforms}
 
     if values == 'all':
         names = []


### PR DESCRIPTION
- Removes "[0]" from the uniform array name