### PR TITLE
objects have no len() by default

### DIFF
--- a/_zengl.py
+++ b/_zengl.py
@@ -312,10 +312,10 @@ def loader(headless=False):
 
         canvas = pyodide_js.canvas.getCanvas3D()
 
-        if not canvas:
+        if canvas is None:
             canvas = js.document.getElementById("canvas")
 
-        if not canvas:
+        if canvas is None:
             canvas = js.document.createElement("canvas")
             canvas.id = "canvas"
             canvas.style.position = "fixed"


### PR DESCRIPTION
undefined and null maps both to None see JSON behaviour
JSON.stringify([undefined])
JSON.stringify([null])

(not) would usually test for len() when the python implementation may not have `__nonzero__` attr support ( eg pocketpy )