### PR TITLE
Fix Broken Examples

### DIFF
--- a/examples/advanced/instanced_crates.py
+++ b/examples/advanced/instanced_crates.py
@@ -18,11 +18,12 @@ image.clear_value = (1.0, 1.0, 1.0, 1.0)
 model = Obj.open(assets.get('box.obj')).pack('vx vy vz nx ny nz tx ty')
 vertex_buffer = ctx.buffer(model)
 
-instance_buffer = ctx.buffer(np.array([
+instance_array = np.array([
     np.repeat(np.linspace(-20.0, 20.0, 30), 30),
     np.tile(np.linspace(-20.0, 20.0, 30), 30),
     np.random.normal(0.0, 0.2, 30 * 30),
-]).T.astype('f4').tobytes())
+]).T.astype('f4')
+instance_buffer = ctx.buffer(instance_array.tobytes())
 
 img = Image.open(assets.get('crate.png')).convert('RGBA')
 texture = ctx.image(img.size, 'rgba8unorm', img.tobytes())
@@ -120,9 +121,8 @@ uniform_buffer.write(struct.pack('3f4x', 3.0, 2.0, 1.5), offset=64)
 
 while window.update():
     ctx.new_frame()
-    z = np.frombuffer(instance_buffer.map(), 'f4').reshape(-1, 3)
-    z[:, 2] += np.random.normal(0.0, 0.01, z.shape[0])
-    instance_buffer.unmap()
+    instance_array[:, 2] += np.random.normal(0.0, 0.01, instance_array.shape[0])
+    instance_buffer.write(instance_array)
 
     image.clear()
     depth.clear()

--- a/examples/advanced/pybullet_box_pile.py
+++ b/examples/advanced/pybullet_box_pile.py
@@ -37,7 +37,8 @@ image.clear_value = (1.0, 1.0, 1.0, 1.0)
 model = Obj.open(assets.get('box.obj')).pack('vx vy vz nx ny nz tx ty')
 vertex_buffer = ctx.buffer(model)
 
-instance_buffer = ctx.buffer(np.zeros((crates, 8)).astype('f4').tobytes())
+instance_array = np.zeros((crates, 8)).astype('f4')
+instance_buffer = ctx.buffer(instance_array.tobytes())
 
 img = Image.open(assets.get('crate.png')).convert('RGBA')
 texture = ctx.image(img.size, 'rgba8unorm', img.tobytes())
@@ -146,13 +147,12 @@ while window.update():
     pb.stepSimulation()
 
     ctx.new_frame()
-    z = np.frombuffer(instance_buffer.map(), 'f4').reshape(-1, 8)
     for i, obj in enumerate(bullet_crates):
         pos, rot = pb.getBasePositionAndOrientation(obj)
-        z[i, :3] = pos
-        z[i, 4:] = rot
+        instance_array[i, :3] = pos
+        instance_array[i, 4:] = rot
 
-    instance_buffer.unmap()
+    instance_buffer.write(instance_array)
 
     image.clear()
     depth.clear()

--- a/examples/advanced/uniform_buffer.py
+++ b/examples/advanced/uniform_buffer.py
@@ -73,14 +73,13 @@ triangle = ctx.pipeline(
 while window.update():
     ctx.new_frame()
     t = window.time
-    z = np.frombuffer(uniform_buffer.map(), 'f4')
-    z[:] = [
+    z = np.array([
         np.sin(t) * 0.1,
         np.cos(t) * 0.1,
         0.7 + np.sin(t * 5) * 0.05,
         0.7 + np.sin(t * 5) * 0.05,
-    ]
-    uniform_buffer.unmap()
+    ], "f4")
+    uniform_buffer.write(z)
 
     image.clear()
     triangle.render()


### PR DESCRIPTION
Some of the examples still use now removed `map()` and `unmap()` methods of `Buffer` objects to write to uniform or instance buffers.  This PR fixes that, replacing them with `write()` calls instead.  In places I moved the munmpy array definition to a separate variable so that it could be written to without having to know the size of the array beforehand, though I suspect they could be reconstructed every frame with a simple `read()` call.