### PR TITLE
Port another batch of examples to pygame-ce window + some fixes

### DIFF
--- a/examples/advanced/blur.py
+++ b/examples/advanced/blur.py
@@ -1,8 +1,8 @@
-import os
 import sys
 
 import pygame
 import zengl
+import zengl_extras
 from monkey import Monkey
 
 
@@ -102,7 +102,7 @@ class Blur2D:
 
 class App:
     def __init__(self):
-        os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
+        zengl_extras.init()
         pygame.init()
         pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
 

--- a/examples/advanced/composer.py
+++ b/examples/advanced/composer.py
@@ -1,23 +1,27 @@
-# TODO:
-# Blending, Grass, WireframeTerrain, ZenglLogo examples are no longer classes
+import sys
 
-import glwindow
+import pygame
 import zengl
-from blending import Blending
-from grass import Grass
-from wireframe_terrain import WireframeTerrain
-from zengl_logo import Logo
+import zengl_extras
+from box_grid import BoxGrid
+from crate import Crate
+from monkey import Monkey
+from sprites import Sprites
 
 
 class App:
     def __init__(self):
-        self.wnd = glwindow.get_window()
-        self.half_size = self.wnd.size[0] // 2, self.wnd.size[1] // 2
+        zengl_extras.init()
+        pygame.init()
+        pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+        window_size = pygame.display.get_window_size()
+
+        self.half_size = window_size[0] // 2, window_size[1] // 2
         self.ctx = zengl.context()
-        self.scene1 = Logo(self.half_size)
-        self.scene2 = WireframeTerrain(self.half_size)
-        self.scene3 = Grass(self.half_size, 100)
-        self.scene4 = Blending(self.half_size)
+        self.scene1 = Monkey(self.half_size)
+        self.scene2 = Crate(self.half_size)
+        self.scene3 = Sprites(self.half_size, 100)
+        self.scene4 = BoxGrid(self.half_size)
 
     def update(self):
         self.ctx.new_frame()
@@ -26,12 +30,22 @@ class App:
         self.scene2.render()
         self.scene3.render()
         self.scene4.render()
-        self.scene1.output.blit(None, (0, h, w, h))
-        self.scene2.output.blit(None, (w, h, w, h))
-        self.scene3.output.blit(None, (0, 0, w, h))
-        self.scene4.output.blit(None, (w, 0, w, h))
+        self.scene1.output.blit(None, (0, h), (w, h))
+        self.scene2.output.blit(None, (w, h), (w, h))
+        self.scene3.output.blit(None, (0, 0), (w, h))
+        self.scene4.output.blit(None, (w, 0), (w, h))
         self.ctx.end_frame()
+
+    def run(self):
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+
+            self.update()
+            pygame.display.flip()
 
 
 if __name__ == "__main__":
-    glwindow.run(App)
+    App().run()

--- a/examples/advanced/example_browser.py
+++ b/examples/advanced/example_browser.py
@@ -1,3 +1,4 @@
+# TODO: port to pygame once `zengl-imgui` release to support latest zengl 2.6 is done
 import importlib
 import os
 import random

--- a/examples/advanced/font_new.py
+++ b/examples/advanced/font_new.py
@@ -1,3 +1,4 @@
+# TODO: port to pygame window and replace `glwindow.load_font``
 import string
 import struct
 import zipfile

--- a/examples/advanced/integrate_imgui.py
+++ b/examples/advanced/integrate_imgui.py
@@ -1,3 +1,4 @@
+# TODO: port to pygame once `zengl-imgui` release to support latest zengl 2.6 is done
 import math
 import struct
 

--- a/examples/advanced/pygame_window.py
+++ b/examples/advanced/pygame_window.py
@@ -1,12 +1,11 @@
 import math
 import struct
 
+import assets
 import pygame as pg
 import zengl
 from objloader import Obj
 from PIL import Image
-
-import assets
 
 window_size = (1280, 720)
 window_aspect = 16.0 / 9.0

--- a/examples/advanced/render_to_cubemap.py
+++ b/examples/advanced/render_to_cubemap.py
@@ -1,17 +1,25 @@
 import gzip
-
-import numpy as np
-import zengl
-from objloader import Obj
+import sys
 
 import assets
-from window import Window
+import numpy as np
+import pygame
+import zengl
+import zengl_extras
+from objloader import Obj
 
-window = Window()
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
-depth = ctx.image(window.size, 'depth24plus', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
+depth = ctx.image(window_size, 'depth24plus', samples=4)
 image.clear_value = (0.2, 0.2, 0.2, 1.0)
 
 uniform_buffer = ctx.buffer(size=64)
@@ -192,7 +200,14 @@ scene_uniform_buffer.write(b''.join([
     zengl.camera((0.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, -1.0, 0.0), fov=90.0),
 ]))
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
+    now  = pygame.time.get_ticks() / 1000.0
+
     ctx.new_frame()
 
     for face, pipeline in scene_pipelines:
@@ -200,9 +215,9 @@ while window.update():
         temp_depth.clear()
         pipeline.render()
 
-    t = window.time * 0.5
+    t = now * 0.5
     eye = (np.cos(t) * 5.0, np.sin(t) * 5.0, np.sin(t * 0.7) * 2.0)
-    camera = zengl.camera(eye, (0.0, 0.0, 0.0), aspect=window.aspect, fov=45.0)
+    camera = zengl.camera(eye, (0.0, 0.0, 0.0), aspect=window_aspect, fov=45.0)
     uniform_buffer.write(camera)
 
     image.clear()
@@ -210,3 +225,5 @@ while window.update():
     shape.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/render_to_texture.py
+++ b/examples/advanced/render_to_texture.py
@@ -1,17 +1,24 @@
-import glwindow
+import sys
+
+import pygame
 import zengl
-from blending import Blending
+import zengl_extras
 from crate import Crate
+from monkey import Monkey
 
 
 class App:
     def __init__(self):
-        self.wnd = glwindow.get_window()
+        zengl_extras.init()
+
+        pygame.init()
+        pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+        window_size = pygame.display.get_window_size()        
         self.ctx = zengl.context()
-        self.scene1 = Blending((256, 256), samples=4)
+        self.scene1 = Monkey(window_size)
         self.scene1.image.clear_value = (0.15, 0.15, 0.15, 1.0)
-        self.scene1.scale = 0.8
-        self.scene2 = Crate(self.wnd.size, texture=self.scene1.output)
+        self.scene2 = Crate(window_size, texture=self.scene1.output)
 
     def update(self):
         self.ctx.new_frame()
@@ -20,6 +27,17 @@ class App:
         self.scene2.output.blit()
         self.ctx.end_frame()
 
+    def run(self):
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+
+            self.update()
+            pygame.display.flip()
+
 
 if __name__ == "__main__":
-    glwindow.run(App)
+    App().run()
+

--- a/examples/advanced/render_to_texture_recursive.py
+++ b/examples/advanced/render_to_texture_recursive.py
@@ -1,17 +1,25 @@
 import math
 import struct
-
-import zengl
-from objloader import Obj
+import sys
 
 import assets
-from window import Window
+import pygame
+import zengl
+import zengl_extras
+from objloader import Obj
 
-window = Window()
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
-depth = ctx.image(window.size, 'depth24plus', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
+depth = ctx.image(window_size, 'depth24plus', samples=4)
 image.clear_value = (1.0, 1.0, 1.0, 1.0)
 
 model = Obj.open(assets.get('box.obj')).pack('vx vy vz nx ny nz tx ty')
@@ -114,10 +122,17 @@ crate_2 = crate_pipeline(texture_1, texture_2, depth_2)
 crate_3 = crate_pipeline(texture_2, texture_3, depth_3)
 crate_4 = crate_pipeline(texture_3, image, depth)
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
+    now  = pygame.time.get_ticks() / 1000.0
+
     ctx.new_frame()
-    x, y = math.sin(window.time * 0.5) * 2.0, math.cos(window.time * 0.5) * 2.0
-    camera = zengl.camera((x, y, 0.8), (0.0, 0.0, -0.15), aspect=window.aspect, fov=45.0)
+    x, y = math.sin(now * 0.5) * 2.0, math.cos(now * 0.5) * 2.0
+    camera = zengl.camera((x, y, 0.8), (0.0, 0.0, -0.15), aspect=window_aspect, fov=45.0)
 
     uniform_buffer.write(camera)
     uniform_buffer.write(struct.pack('3f4x', x, y, 1.5), offset=64)
@@ -140,3 +155,5 @@ while window.update():
 
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/sdf_example.py
+++ b/examples/advanced/sdf_example.py
@@ -1,11 +1,12 @@
 # pip install https://github.com/fogleman/sdf/archive/refs/heads/main.zip
 import math
+import sys
 
 import numpy as np
+import pygame
 import sdf
 import zengl
-
-from window import Window
+import zengl_extras
 
 c = sdf.cylinder(0.5)
 f = sdf.sphere(1) & sdf.box(1.5)
@@ -43,11 +44,18 @@ tmp = points.reshape(-1, 3, 3)
 normals = np.repeat(np.cross(tmp[:, 1] - tmp[:, 0], tmp[:, 2] - tmp[:, 0]), 3, axis=0)
 radius = np.max(np.sqrt(np.sum(points * points, axis=1)))
 
-window = Window()
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
-depth = ctx.image(window.size, 'depth24plus', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
+depth = ctx.image(window_size, 'depth24plus', samples=4)
 image.clear_value = (0.2, 0.2, 0.2, 1.0)
 
 mesh = np.concatenate([points, normals], axis=1).astype('f4').tobytes()
@@ -110,10 +118,17 @@ model = ctx.pipeline(
     vertex_count=vertex_buffer.size // 24,
 )
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
+    now  = pygame.time.get_ticks() / 1000.0
+
     ctx.new_frame()
-    x, y = math.sin(window.time * 0.5) * 2.5 * radius, math.cos(window.time * 0.5) * 2.5 * radius
-    camera = zengl.camera((x, y, 1.5 * radius), (0.0, 0.0, 0.0), aspect=window.aspect, fov=45.0)
+    x, y = math.sin(now * 0.5) * 2.5 * radius, math.cos(now * 0.5) * 2.5 * radius
+    camera = zengl.camera((x, y, 1.5 * radius), (0.0, 0.0, 0.0), aspect=window_aspect, fov=45.0)
 
     uniform_buffer.write(camera)
 
@@ -122,3 +137,5 @@ while window.update():
     model.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/shader_include.py
+++ b/examples/advanced/shader_include.py
@@ -1,11 +1,20 @@
+import sys
+
 import numpy as np
+import pygame
 import zengl
+import zengl_extras
 
-from window import Window
+zengl_extras.init()
 
-window = Window()
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
 image.clear_value = (1.0, 1.0, 1.0, 1.0)
 
 ctx.includes['vertex_attributes'] = '''
@@ -57,9 +66,16 @@ triangle = ctx.pipeline(
     vertex_count=3,
 )
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
     ctx.new_frame()
     image.clear()
     triangle.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/shadow.py
+++ b/examples/advanced/shadow.py
@@ -1,16 +1,24 @@
 import struct
-
-import zengl
-from objloader import Obj
+import sys
 
 import assets
-from window import Window
+import pygame
+import zengl
+import zengl_extras
+from objloader import Obj
 
-window = Window()
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
-depth = ctx.image(window.size, 'depth24plus', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
+depth = ctx.image(window_size, 'depth24plus', samples=4)
 image.clear_value = (0.03, 0.03, 0.03, 1.0)
 
 ctx.includes['ubo'] = '''
@@ -231,7 +239,7 @@ light_color = [
 ]
 
 eye = (3.0, 2.0, 2.0)
-camera = zengl.camera(eye, (0.0, 0.0, 0.0), aspect=window.aspect, fov=45.0)
+camera = zengl.camera(eye, (0.0, 0.0, 0.0), aspect=window_aspect, fov=45.0)
 uniform_buffer.write(struct.pack(
     '=64s3f4x64s64s64s3f4x3f4x3f4x4f4f4f',
     camera, *eye,
@@ -240,7 +248,12 @@ uniform_buffer.write(struct.pack(
     *light_color[0], *light_color[1], *light_color[2],
 ))
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
     ctx.new_frame()
     image.clear()
     depth.clear()
@@ -254,3 +267,5 @@ while window.update():
     scene.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/soft_body_simulation.py
+++ b/examples/advanced/soft_body_simulation.py
@@ -1,12 +1,21 @@
+import sys
+
 import numpy as np
+import pygame
 import zengl
+import zengl_extras
 
-from window import Window
+zengl_extras.init()
 
-window = Window((512, 512))
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
 image.clear_value = (1.0, 1.0, 1.0, 1.0)
 
 N = 16
@@ -341,7 +350,12 @@ constraint_edges_pipeline = ctx.pipeline(
 points.blit(points_temp1)
 points.blit(points_temp2)
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
     ctx.new_frame()
     image.clear()
     points_temp2.blit(points_temp1)
@@ -353,3 +367,5 @@ while window.update():
     points_pipeline.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/sprites.py
+++ b/examples/advanced/sprites.py
@@ -1,11 +1,12 @@
+import sys
 import zipfile
 
-import glwindow
-import numpy as np
-import zengl
-from PIL import Image
-
 import assets
+import numpy as np
+import pygame
+import zengl
+import zengl_extras
+from PIL import Image
 
 
 class Sprites:
@@ -122,9 +123,12 @@ class Sprites:
 
 class App:
     def __init__(self):
-        self.wnd = glwindow.get_window()
+        zengl_extras.init()
+
+        pygame.init()
+        pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)        
         self.ctx = zengl.context()
-        self.scene = Sprites(self.wnd.size, 100)
+        self.scene = Sprites(pygame.display.get_window_size(), 100)
 
     def update(self):
         self.ctx.new_frame()
@@ -132,6 +136,16 @@ class App:
         self.scene.output.blit()
         self.ctx.end_frame()
 
+    def run(self):
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+
+            self.update()
+            pygame.display.flip()
+
 
 if __name__ == "__main__":
-    glwindow.run(App)
+    App().run()

--- a/examples/advanced/ssao_from_depth.py
+++ b/examples/advanced/ssao_from_depth.py
@@ -1,5 +1,8 @@
-import glwindow
+import sys
+
+import pygame
 import zengl
+import zengl_extras
 from monkey import Monkey
 
 
@@ -200,9 +203,12 @@ class SSAO:
 
 class App:
     def __init__(self):
-        self.wnd = glwindow.get_window()
+        zengl_extras.init()
+
+        pygame.init()
+        pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)            
         self.ctx = zengl.context()
-        self.scene = Monkey(self.wnd.size, samples=1)
+        self.scene = Monkey(pygame.display.get_window_size(), samples=1)
         self.ssao = SSAO(self.scene.depth, self.scene.uniform_buffer)
 
     def update(self):
@@ -212,6 +218,16 @@ class App:
         self.ssao.output.blit()
         self.ctx.end_frame()
 
+    def run(self):
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
 
-if __name__ == '__main__':
-    glwindow.run(App)
+            self.update()
+            pygame.display.flip()
+
+
+if __name__ == "__main__":
+    App().run()

--- a/examples/advanced/stencil.py
+++ b/examples/advanced/stencil.py
@@ -1,14 +1,23 @@
-import zengl
-from objloader import Obj
+import sys
 
 import assets
-from window import Window
+import pygame
+import zengl
+import zengl_extras
+from objloader import Obj
 
-window = Window()
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
-depth_stencil = ctx.image(window.size, 'depth24plus-stencil8', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
+depth_stencil = ctx.image(window_size, 'depth24plus-stencil8', samples=4)
 image.clear_value = (1.0, 1.0, 1.0, 1.0)
 depth_stencil.clear_value = (1.0, 0)
 
@@ -142,10 +151,15 @@ monkey = ctx.pipeline(
     vertex_count=vertex_buffer.size // zengl.calcsize('3f 3f'),
 )
 
-camera = zengl.camera((3.0, 2.0, 2.0), (0.0, 0.0, 0.5), aspect=window.aspect, fov=45.0)
+camera = zengl.camera((3.0, 2.0, 2.0), (0.0, 0.0, 0.5), aspect=window_aspect, fov=45.0)
 uniform_buffer.write(camera)
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
     ctx.new_frame()
     depth_stencil.clear()
     image.clear()
@@ -153,3 +167,5 @@ while window.update():
     monkey.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/streaming_video.py
+++ b/examples/advanced/streaming_video.py
@@ -1,22 +1,35 @@
+import sys
 from itertools import cycle
 
+import assets
 import imageio
 import numpy as np
+import pygame
 import zengl
-
-import assets
-from window import Window
+import zengl_extras
 
 reader = imageio.get_reader(assets.get('bunny.mp4'))  # https://test-videos.co.uk/bigbuckbunny/mp4-h264
 it = cycle(reader)
 
-window = Window()
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+window_size = pygame.display.get_window_size()
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm')
+image = ctx.image(window_size, 'rgba8unorm')
 frame = np.zeros((720, 1280, 4), 'u1')
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
     frame[::-1, :, 0:3] = next(it)
     image.write(frame)
     image.blit()
+
+    pygame.display.flip()

--- a/examples/advanced/streaming_webcam.py
+++ b/examples/advanced/streaming_webcam.py
@@ -1,20 +1,44 @@
-import imageio
+import sys
+
+import cv2
 import numpy as np
+import pygame
 import zengl
+import zengl_extras
 
-from window import Window
+cap = cv2.VideoCapture(index=1)  # (try different indices if 1 doesn't work)
+if not cap.isOpened():
+    raise RuntimeError("Could not open webcam")
 
-reader = imageio.get_reader('<video0>')
-it = iter(reader)
-height, width = next(it).shape[:2]
-frame = np.zeros((height, width, 4), 'u1')
+ret, cv_frame = cap.read()
+if not ret:
+    raise RuntimeError("Failed to grab initial frame from webcam")
 
-window = Window((width, height))
+height, width = cv_frame.shape[:2]
+window_size = (width, height)
+
+zengl_extras.init()
+
+pygame.init()
+pygame.display.set_mode(window_size, flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm')
+image = ctx.image(window_size, 'rgba8unorm')
 
-while window.update():
-    frame[::-1, ::-1, 0:3] = next(it)
-    image.write(frame)
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
+    ret, frame = cap.read()
+    if not ret:
+        continue
+
+    rgba = cv2.cvtColor(frame, cv2.COLOR_BGR2RGBA)
+    flipped_frame = np.flip(rgba, axis=(0, 1))
+    image.write(flipped_frame)
     image.blit()
+
+    pygame.display.flip()

--- a/examples/advanced/uniform_buffer.py
+++ b/examples/advanced/uniform_buffer.py
@@ -1,12 +1,21 @@
+import sys
+
 import numpy as np
+import pygame
 import zengl
+import zengl_extras
 
-from window import Window
+zengl_extras.init()
 
-window = Window()
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+window_aspect = window_size[0] / window_size[1]
+
 ctx = zengl.context()
 
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
 image.clear_value = (1.0, 1.0, 1.0, 1.0)
 
 uniform_buffer = ctx.buffer(size=16)
@@ -70,14 +79,20 @@ triangle = ctx.pipeline(
     vertex_count=3,
 )
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
+    now  = pygame.time.get_ticks() / 1000.0
+
     ctx.new_frame()
-    t = window.time
     z = np.array([
-        np.sin(t) * 0.1,
-        np.cos(t) * 0.1,
-        0.7 + np.sin(t * 5) * 0.05,
-        0.7 + np.sin(t * 5) * 0.05,
+        np.sin(now) * 0.1,
+        np.cos(now) * 0.1,
+        0.7 + np.sin(now * 5) * 0.05,
+        0.7 + np.sin(now * 5) * 0.05,
     ], "f4")
     uniform_buffer.write(z)
 
@@ -85,3 +100,5 @@ while window.update():
     triangle.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/advanced/vertex_buffer.py
+++ b/examples/advanced/vertex_buffer.py
@@ -1,11 +1,19 @@
+import sys
+
 import numpy as np
+import pygame
 import zengl
+import zengl_extras
 
-from window import Window
+zengl_extras.init()
 
-window = Window()
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+
+window_size = pygame.display.get_window_size()
+
 ctx = zengl.context()
-image = ctx.image(window.size, 'rgba8unorm', samples=4)
+image = ctx.image(window_size, 'rgba8unorm', samples=4)
 image.clear_value = (1.0, 1.0, 1.0, 1.0)
 
 vertex_buffer = ctx.buffer(np.array([
@@ -47,9 +55,16 @@ triangle = ctx.pipeline(
     vertex_count=3,
 )
 
-while window.update():
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+
     ctx.new_frame()
     image.clear()
     triangle.render()
     image.blit()
     ctx.end_frame()
+
+    pygame.display.flip()

--- a/examples/basic/matcap.py
+++ b/examples/basic/matcap.py
@@ -1,3 +1,5 @@
+# TODO: missing assets for 'downloads/matcap/*.png'
+
 import glob
 import itertools
 import math

--- a/examples/examples_requirements.txt
+++ b/examples/examples_requirements.txt
@@ -17,3 +17,5 @@ pygmsh
 https://github.com/fogleman/sdf/archive/refs/heads/main.zip
 imageio[ffmpeg]
 opencv-python
+meshtools
+pyopengl

--- a/examples/examples_requirements.txt
+++ b/examples/examples_requirements.txt
@@ -14,3 +14,6 @@ pyglm
 scikit-image
 pybullet
 pygmsh
+https://github.com/fogleman/sdf/archive/refs/heads/main.zip
+imageio[ffmpeg]
+opencv-python

--- a/examples/pygame/crate.py
+++ b/examples/pygame/crate.py
@@ -1,5 +1,4 @@
 import math
-import os
 import struct
 import sys
 
@@ -7,10 +6,10 @@ import pygame
 import zengl
 import zengl_extras
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
 
 zengl_extras.download('crate.zip')
 
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((720, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
 

--- a/examples/pygame/hello_world.py
+++ b/examples/pygame/hello_world.py
@@ -1,11 +1,10 @@
-import os
 import sys
 
 import pygame
 import zengl
+import zengl_extras
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
 

--- a/examples/pygame/postprocessing.py
+++ b/examples/pygame/postprocessing.py
@@ -1,13 +1,12 @@
-import os
 import random
 import struct
 import sys
 
 import pygame
 import zengl
+import zengl_extras
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((640, 480), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
 screen = pygame.surface.Surface((320, 240))

--- a/examples/pygame/resizable_window_crop.py
+++ b/examples/pygame/resizable_window_crop.py
@@ -3,9 +3,9 @@ import sys
 
 import pygame
 import zengl
+import zengl_extras
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF | pygame.RESIZABLE, vsync=True)
 

--- a/examples/pygame/resizable_window_scale.py
+++ b/examples/pygame/resizable_window_scale.py
@@ -1,11 +1,10 @@
-import os
 import sys
 
 import pygame
 import zengl
+import zengl_extras
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF | pygame.RESIZABLE, vsync=True)
 

--- a/examples/pygame/surface_overlay.py
+++ b/examples/pygame/surface_overlay.py
@@ -4,9 +4,9 @@ import sys
 
 import pygame
 import zengl
+import zengl_extras
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((640, 480), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
 

--- a/examples/pyglet/resizable_window.py
+++ b/examples/pyglet/resizable_window.py
@@ -17,7 +17,7 @@ window = pyglet.window.Window(1280, 720, resizable=True, config=config, vsync=Tr
 
 ctx = zengl.context()
 
-display = pyglet.canvas.Display()
+display = pyglet.display.get_display()
 screen = display.get_default_screen()
 image = ctx.image((screen.width, screen.height), 'rgba8unorm', samples=4)
 

--- a/examples/pyopengl/wide_lines.py
+++ b/examples/pyopengl/wide_lines.py
@@ -4,16 +4,15 @@
     To render nice lines please see the bezier_curves.py.
 '''
 
-import os
 import sys
 
 import numpy as np
 import pygame
 import zengl
+import zengl_extras
 from OpenGL import GL
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
 


### PR DESCRIPTION
Ports the last batch of examples/advanced to pygame-ce window.

I've almost been able to run them all now - there are some awesome examples in here I hadn't seen before - zengl is so cool!

For streaming_webcam.py, I couldn't get it to work with `imageio`, tried a handful of fixes but got either `IndexError: No ffdshow camera at index %.` or `FileNotFoundError` no matter what, so I changed it to use OpenCV and works great for me (am on Windows - assuming other platforms will be fine with this too)

Remaining issues/questions:
1) For the ones that use `imgui` ([example_browser.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/example_browser.py) and [integrate_imgui.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/integrate_imgui.py)), I'll wait for you to release new version of `zengl-imgui` for the 2.6 compability fix, then I'll update these
2) Assets for [matcap.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/basic/matcap.py) need uploading to b2
3) Assets for [cubemap_debugger.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/cubemap_debugger.py) need uploading to b2
4) [uniforms_mutate.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/uniforms_mutate.py) and [uniforms.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/uniforms.py) have a note saying "This is the NOT recommanded way to do it." - should these be removed?
5) Similarly [uvsphere_to_cubemap.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/uvsphere_to_cubemap.py) looks to be deprecated by panorama_to_cubemap.py, should this one be removed?
6) Should [window.py ](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/window.py) be removed now it's no longer used, or do you want to keep it?
7) [font_new.py](https://github.com/szabolcsdombi/zengl/blob/main/examples/advanced/font_new.py) I need to look at how to replace glwindow.load_font, will do that in a follow up
