### PR TITLE
Few examples touch ups

### DIFF
--- a/examples/advanced/font_new.py
+++ b/examples/advanced/font_new.py
@@ -1,10 +1,13 @@
-# TODO: port to pygame window and replace `glwindow.load_font``
+# pip install https://github.com/szabolcsdombi/font-atlas/archive/refs/heads/main.zip
 import string
 import struct
+import sys
 import zipfile
 
-import glwindow
+from font_atlas import load_font
+import pygame
 import zengl
+import zengl_extras
 
 import assets
 
@@ -26,7 +29,7 @@ class FontDemo:
         code_points = [ord(x) for x in string.printable]
 
         texture_size = (512, 512)
-        pixels, glyphs = glwindow.load_font(texture_size, fonts, self.font_sizes, code_points)
+        pixels, glyphs = load_font(texture_size, fonts, self.font_sizes, code_points)
 
         self.glyph_lookup = {x: i for i, x in enumerate(code_points)}
         self.glyph_struct = struct.Struct("Q3f")
@@ -149,9 +152,11 @@ class FontDemo:
 
 class App:
     def __init__(self):
-        self.wnd = glwindow.get_window()
+        zengl_extras.init()
+        pygame.init()
+        pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
         self.ctx = zengl.context()
-        self.scene = FontDemo(self.wnd.size)
+        self.scene = FontDemo(pygame.display.get_window_size())
 
         self.scene.clear()
         self.scene.text(100.0, 100.0, "Hello World!", "regular", 16.0, "#ff0000")
@@ -168,6 +173,16 @@ class App:
         self.scene.output.blit()
         self.ctx.end_frame()
 
+    def run(self):
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+
+            self.update()
+            pygame.display.flip()
+
 
 if __name__ == "__main__":
-    glwindow.run(App)
+    App().run()

--- a/examples/advanced/shadertoy.py
+++ b/examples/advanced/shadertoy.py
@@ -120,7 +120,7 @@ while True:
         now,
         now - last_time,
         frame,
-        mouse_pos[0], mouse_pos[1], 0.0, 0.0,
+        mouse_pos[0], window_size[1] - mouse_pos[1], 0.0, 0.0,
         0.0, 0.0, 0.0, 0.0,
     ))
     canvas.render()

--- a/examples/examples_requirements.txt
+++ b/examples/examples_requirements.txt
@@ -19,3 +19,5 @@ imageio[ffmpeg]
 opencv-python
 meshtools
 pyopengl
+https://github.com/szabolcsdombi/layered-window/archive/refs/heads/main.zip
+https://github.com/szabolcsdombi/font-atlas/archive/refs/heads/main.zip

--- a/examples/experimental/angle_backend.py
+++ b/examples/experimental/angle_backend.py
@@ -1,9 +1,12 @@
+# NOTE: Copy a 'libGLESv2.dll' file to the same directory as this script. (VSCode or Chrome has one next to their exe)
 import ctypes
 import sys
 
 import pygame
 import zengl
+import zengl_extras
 
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((800, 600))
 

--- a/examples/experimental/layered_window_obs.py
+++ b/examples/experimental/layered_window_obs.py
@@ -70,7 +70,7 @@ pipeline = ctx.pipeline(
     instance_count=10,
 )
 
-mem = layered_window.init((400, 400), title='Animation', always_on_top=True, tool_window=True)
+mem = layered_window.init((400, 400), title='Animation')
 start_time = time.perf_counter()
 
 while True:

--- a/examples/experimental/layered_window_obs.py
+++ b/examples/experimental/layered_window_obs.py
@@ -1,10 +1,13 @@
+# pip install https://github.com/szabolcsdombi/layered-window/archive/refs/heads/main.zip
 import array
 import struct
 import time
 
 import layered_window
 import zengl
+import zengl_extras
 
+zengl_extras.init()
 zengl.init(zengl.loader(headless=True))
 ctx = zengl.context()
 
@@ -67,7 +70,7 @@ pipeline = ctx.pipeline(
     instance_count=10,
 )
 
-mem = layered_window.init((400, 400), title='Animation')
+mem = layered_window.init((400, 400), title='Animation', always_on_top=True, tool_window=True)
 start_time = time.perf_counter()
 
 while True:


### PR DESCRIPTION
A few extras bits I noticed:

- font_new.py have now ported & got working with your `font_atlas` package
- fixed mouse pos Y flip for shadertoy.py
- add a couple comments for the libGLESv2.dll and layered_window reqs

I started to look at the imgui ones, but it seems [pyimgui](https://github.com/pyimgui/pyimgui) is not installable with python 3.13 & is no longer maintained 😢 seems that [imgui_bundle](https://github.com/pthom/imgui_bundle) gets its bindings auto updated and this installs fine, but it's not compatible with the current `zengl-imgui` module... am gonna have a go at adapting it, will let you know how it goes!